### PR TITLE
Feature/x86 android emulators

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       }
     ],
     "keybindings": [
-     {
+      {
         "key": "ctrl+alt+e",
         "mac": "cmd+alt+e",
         "command": "emulator.start"
@@ -45,10 +45,10 @@
     ],
     "menus": {
       "editor/title": [
-				{
-					"command": "emulator.start",
-					"when": "editorFocus",
-					"group": "navigation"
+        {
+          "command": "emulator.start",
+          "when": "editorFocus",
+          "group": "navigation"
         }
       ]
     },
@@ -57,8 +57,8 @@
       "properties": {
         "emulator.emulatorPath": {
           "type": "string",
-          "default": "~/Library/Android/sdk/tools/emulator",
-          "description": "The absolute path of the Android emulator script.",
+          "default": "~/Library/Android/sdk/emulator",
+          "description": "The absolute path of the Android directory containing the emulator script.",
           "scope": "application"
         }
       }

--- a/src/android.js
+++ b/src/android.js
@@ -1,5 +1,6 @@
+const path = require('path');
 const { window } = require('vscode');
-const { emulatorPath } = require('./config')
+const { emulatorPath } = require('./config');
 const { runCmd } = require('./utils/commands');
 const { showSuccessMessage, showErrorMessage } = require('./utils/message');
 const { ANDROID_COMMANDS } = require('./constants');
@@ -8,7 +9,10 @@ const { ANDROID_COMMANDS } = require('./constants');
 exports.androidPick = async () => {
   const emulators = await getAndroidEmulators();
   if (emulators) {
-    const formattedEmulators = emulators.map(e => ({ label: e.replace(/_/g, ' '), emulator: e }))
+    const formattedEmulators = emulators.map(e => ({
+      label: e.replace(/_/g, ' '),
+      emulator: e
+    }));
     window.showQuickPick(formattedEmulators).then(response => {
       if (response) {
         const ranEmulator = runAndroidEmulator(response.emulator);
@@ -20,14 +24,22 @@ exports.androidPick = async () => {
       }
     });
   }
-}
+};
 
 const getAndroidEmulators = async () => {
-  let { stdout } = await runCmd(`${emulatorPath()}${ANDROID_COMMANDS.LIST_AVDS}`);
-  return stdout && stdout.trim().split('\n') || false;
+  let { stdout } = await runCmd(
+    `${path.join(emulatorPath(), 'emulator')}${ANDROID_COMMANDS.LIST_AVDS}`,
+    { cwd: emulatorPath().replace('~', process.env.HOME) }
+  );
+  return (stdout && stdout.trim().split('\n')) || false;
 };
 
 const runAndroidEmulator = async emulator => {
-  let { stdout } = await runCmd(`${emulatorPath()}${ANDROID_COMMANDS.RUN_AVD}${emulator}`);
+  let { stdout } = await runCmd(
+    `${path.join(emulatorPath(), 'emulator')}${
+      ANDROID_COMMANDS.RUN_AVD
+    }${emulator}`,
+    { cwd: emulatorPath().replace('~', process.env.HOME) }
+  );
   return stdout || false;
 };

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -1,8 +1,8 @@
 const { exec } = require('child_process');
 
-exports.runCmd = async cmd => {
+exports.runCmd = async (cmd, options) => {
   return new Promise((resolve, reject) => {
-    exec(cmd, (err, stdout, stderr) => {
+    exec(cmd, options, (err, stdout, stderr) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
Closes #12 

This update resolves the issue of starting up x86 emulators on a mac. I only tested it on a mac since I don't have access to a windows machine at the moment but I see not reason why it wouldn't work for Windows too.

There is a breaking change in this one. Instead of pointing to the actual emulator script you are now supposed to point to the directory containing the emulator script. I have updated the default value and the description accordingly.