### PR TITLE
Added linux path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To run Android emulators you need to have Android studio and already created the
 Add the Android Studio emulator script to your settings in Visual Studio Code:  
 &nbsp;&nbsp;&nbsp;&nbsp;Mac: `"emulator.emulatorPath": "~/Library/Android/sdk/tools/emulator"`  
 &nbsp;&nbsp;&nbsp;&nbsp;Windows: `"emulator.emulatorPath": "<your android home>\\Sdk\\emulator\\emulator.exe"`
+&nbsp;&nbsp;&nbsp;&nbsp;Linux: `"emulator.emulatorPath": "~/Android/Sdk/emulator"`
 
 Your visual studio code settings are found here:  
 &nbsp;&nbsp;&nbsp;&nbsp;File -> Preferences -> Setting -> User Setting -> Extensions -> Emulator Configuration


### PR DESCRIPTION
On Ubuntu (18.04) Android studio installs emulator script by default to directory `~/Android/Sdk/emulator`