### PR TITLE
Add extra boot args to android emulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "default": false,
           "description": "Show an option to cold boot android devices."
         },
+        "emulator.androidExtraBootArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Add extra boot args to the android emulator"
+        },
         "emulator.hasEditorTitleIcon": {
           "type": "boolean",
           "default": true,

--- a/src/android.js
+++ b/src/android.js
@@ -4,6 +4,7 @@ const { emulatorPath } = require('./config')
 const { runCmd } = require('./utils/commands')
 const { showErrorMessage } = require('./utils/message')
 const { ANDROID_COMMANDS, ANDROID } = require('./constants')
+const { androidExtraBootArgs } = require('./config')
 
 // Get Android devices and pick one
 exports.androidPick = async (cold = false) => {
@@ -71,7 +72,7 @@ const runAndroidEmulator = async (emulator, cold) => {
     return false
   }
 
-  const command = `${getEmulatorPath(androidPath)}${
+  const command = `${getEmulatorPath(androidPath)} ${androidExtraBootArgs()}${
     cold ? ANDROID_COMMANDS.RUN_AVD_COLD : ANDROID_COMMANDS.RUN_AVD
   }${emulator}`
   try {

--- a/src/config.js
+++ b/src/config.js
@@ -38,3 +38,6 @@ exports.emulatorPath = () => {
 exports.androidColdBoot = () => {
   return config().get('androidColdBoot')
 }
+exports.androidExtraBootArgs = () => {
+  return config().get('androidExtraBootArgs')
+}


### PR DESCRIPTION
Hi, 
Since I can only launch an Android Emulator with args "-gpu host" on my computer. (not sure the reason)
I cannot use the extension directly on my Mac.

So I add a new parameter called "androidExtraBootArgs" which allow you to add some extra args while run a ./emulator cmd.

This is also helpful to test some features on ./emulator with custom args.

Hopes can be merged into the repository and publish on VS code Marketplace.
Thanks.