### PR TITLE
Fix #44 ios simulator not working

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,8 +11,9 @@ exports.ANDROID_COMMANDS = {
 }
 
 exports.IOS_COMMANDS = {
-  LIST_SIMULATORS: 'instruments -s devices',
-  RUN_SIMULATOR: 'instruments -w ',
+  LIST_SIMULATORS: 'xcrun simctl list --json devices',
+  DEVELOPER_DIR: 'xcode-select -p',
+  RUN_SIMULATOR: '/Applications/Simulator.app --args -CurrentDeviceUDID ',
 }
 
 exports.ANDROID = {


### PR DESCRIPTION
Fix for https://github.com/DiemasMichiels/emulator/issues/44 to not use the `instruments` commands which are removed in Xcode 13