### PR TITLE
Typofix and loading emulators on windows

### DIFF
--- a/src/android.js
+++ b/src/android.js
@@ -1,10 +1,9 @@
 const path = require('path')
 const { window } = require('vscode')
-const { emulatorPath } = require('./config')
+const { getPath, androidExtraBootArgs } = require('./config')
 const { runCmd } = require('./utils/commands')
 const { showErrorMessage } = require('./utils/message')
 const { ANDROID_COMMANDS, ANDROID } = require('./constants')
-const { androidExtraBootArgs } = require('./config')
 
 // Get Android devices and pick one
 exports.androidPick = async (cold = false) => {
@@ -23,17 +22,14 @@ exports.androidPick = async (cold = false) => {
 }
 
 const getAndroidPath = async () => {
-  return (await runCmd(`echo "${emulatorPath()}"`))
+  return (await runCmd(`echo "${getPath()}"`))
     .trim()
     .replace(/[\n\r"]/g, '')
 }
 
 const getEmulatorPath = (androidPath) => {
   const emulatorPath = path.join(androidPath, ANDROID.PATH)
-  if (process.platform.startsWith('win')) {
-    return `"${emulatorPath}"`
-  }
-  return emulatorPath
+  return process.platform.startsWith('win') ? `"${emulatorPath}"` : emulatorPath
 }
 
 const getAndroidEmulators = async (cold) => {
@@ -58,7 +54,7 @@ const getAndroidEmulators = async (cold) => {
   } catch (e) {
     showErrorMessage(e.toString())
     showErrorMessage(
-      `Something went wrong fetching you Android emulators! Make sure your path is correct. Try running this command in your terminal: ${command}`,
+      `Something went wrong fetching your Android emulators! Make sure your path is correct. Try running this command in your terminal: ${command}`,
     )
     return false
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,11 @@
 const { workspace } = require('vscode')
-const { showErrorMessage } = require('./utils/message')
 
-const config = () => {
-  return workspace.getConfiguration('emulator')
-}
+const config = workspace.getConfiguration('emulator')
 
-const getPath = () => {
-  const pathMac = config().get('emulatorPathMac')
-  const pathLinux = config().get('emulatorPathLinux')
-  const pathWindows = config().get('emulatorPathWindows')
+exports.getPath = () => {
+  const pathMac = config.get('emulatorPathMac')
+  const pathLinux = config.get('emulatorPathLinux')
+  const pathWindows = config.get('emulatorPathWindows')
 
   if (process.platform === 'darwin' && pathMac) {
     return pathMac
@@ -19,30 +16,17 @@ const getPath = () => {
   if (process.platform.startsWith('win') && pathWindows) {
     return pathWindows
   }
-  return config().get('emulatorPath')
-}
-
-exports.emulatorPath = () => {
-  const path = getPath()
-
-  if (process.platform.startsWith('win') && path.includes('/')) {
-    showErrorMessage(
-      'Make sure your Windows path is set correctly! Example: C:\\Users\\Me\\AppData\\Local\\Android\\Sdk\\emulator',
-    )
-    return false
-  }
-
-  return path
+  return config.get('emulatorPath')
 }
 
 exports.androidColdBoot = () => {
-  return config().get('androidColdBoot')
+  return config.get('androidColdBoot')
 }
 
 exports.simulatorPath = () => {
-  return config().get('simulatorPath')
+  return config.get('simulatorPath')
 }
 
 exports.androidExtraBootArgs = () => {
-  return config().get('androidExtraBootArgs')
+  return config.get('androidExtraBootArgs')
 }


### PR DESCRIPTION
Fixes #39 

Windows terminals (cmd, powershell, gitbash, etc.) all support the use of forwardslash (`/`), so allowing it in the path is acceptable. 
As such, I removed the check for forwardslashes in the path and just allowed it, which works on my machine running windows 10.

To preserve backslash functionality, the command still wraps the path in quotes.
Additionally, since `getEmulatorPath` was the same function as `getPath` with the additional handling for the aforementioned issue, I removed the function.

I also made a typofix to the error message: `you Android emulators!` -> `your Android emulators!`
and did some cleaning up here and there to keep things tidy.