### PR TITLE
chore: remove unnecessary child_process dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,12 @@
       "name": "emulate",
       "version": "1.7.1",
       "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "child_process": "1.0.2"
-      },
       "devDependencies": {
         "prettier": "^2.3.2"
       },
       "engines": {
         "vscode": "^1.22.0"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
     "node_modules/prettier": {
       "version": "2.3.2",
@@ -37,11 +29,6 @@
     }
   },
   "dependencies": {
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -109,9 +109,7 @@
   "devDependencies": {
     "prettier": "^2.3.2"
   },
-  "dependencies": {
-    "child_process": "1.0.2"
-  },
+  "dependencies": {},
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",


### PR DESCRIPTION
remove unnecessary child_process dependency
child_process is a Node.js built-in module and does not need to be installed via npm.